### PR TITLE
Fall back to default .js handler for unknown extensions

### DIFF
--- a/fixture.cjs
+++ b/fixture.cjs
@@ -1,0 +1,1 @@
+module.exports = 'foobar-cjs';

--- a/index.js
+++ b/index.js
@@ -1,16 +1,18 @@
 'use strict';
 module.exports = install;
 
-// We need to save it before it gets overriden by install
-const defaultHandler = require.extensions['.js']; // eslint-disable-line node/no-deprecated-api
+/* eslint-disable node/no-deprecated-api, eslint-comments/disable-enable-pair */
 
-function install(precompile, ext = '.js', extensions = require.extensions) { // eslint-disable-line node/no-deprecated-api
-	const {[ext]: oldExtension = defaultHandler} = extensions;
+// Save reference before a new handler is installed.
+const {'.js': defaultHandler} = require.extensions;
+
+function install(precompile, ext = '.js', extensions = require.extensions) {
+	const {[ext]: fallbackHandler = defaultHandler} = extensions;
 
 	extensions[ext] = function (module, filename) {
 		const source = precompile(filename);
 		if (source === null) {
-			Reflect.apply(oldExtension, extensions, [module, filename]);
+			Reflect.apply(fallbackHandler, extensions, [module, filename]);
 		} else {
 			module._compile(source, filename);
 		}

--- a/index.js
+++ b/index.js
@@ -1,11 +1,16 @@
 'use strict';
 module.exports = install;
 
+// we need to save it before it gets overriden by install
+const defaultHandler = require.extensions['.js'];
+
 function install(precompile, ext, extensions) {
 	ext = ext || '.js';
 	extensions = extensions || require.extensions;
 
-	var oldExtension = extensions[ext];
+	// if there is no handler in extensions(as in case with .cjs)
+	// use the default one which we saved before
+	var oldExtension = extensions[ext] || defaultHandler;
 
 	extensions[ext] = function (module, filename) {
 		var source = precompile(filename);

--- a/test.js
+++ b/test.js
@@ -64,3 +64,12 @@ test('test actual require', t => {
 
 	t.is(require('./fixture'), 'foobar');
 });
+
+test('test require extension without previous handler extension', t => {
+	install(
+		() => null,
+		'.cjs'
+	);
+
+	t.is(require('./fixture.cjs'), 'foobar-cjs');
+});


### PR DESCRIPTION
This PR fixes the problem described here [https://github.com/avajs/babel/issues/22](https://github.com/avajs/babel/issues/22)
 
After installing require-precompiled for `cjs` files  `require()` breaks and crashes when loading any `cjs` module.
  
This problem will emerge with any extension that is not present in the require.extensions in the moment of require-precompiled installation. 

This problem was not checked before because most of the tests use fake modules without dealing with require.extensions.

This PR  adds a small fix in index.js and one simple test